### PR TITLE
Python 3 compatibility

### DIFF
--- a/srtm/data.py
+++ b/srtm/data.py
@@ -24,10 +24,6 @@ import logging as mod_logging
 import math as mod_math
 import re as mod_re
 import os.path as mod_path
-try:
-    import cStringIO as mod_cstringio
-except:
-    from io import StringIO as mod_cstringio
 import struct as mod_struct
 
 from . import utils as mod_utils
@@ -37,8 +33,8 @@ import requests as mod_requests
 
 class GeoElevationData:
     """
-    The main class with utility methods for elevations. Note that files are 
-    loaded in memory, so if you need to find elevations for multiple points on 
+    The main class with utility methods for elevations. Note that files are
+    loaded in memory, so if you need to find elevations for multiple points on
     the earth -- this will load *many* files in memory!
     """
 
@@ -78,7 +74,7 @@ class GeoElevationData:
         If the file can't be found -- it will be retrieved from the server.
         """
         file_name = self.get_file_name(latitude, longitude)
-		
+
         if not file_name:
             return None
 
@@ -147,7 +143,7 @@ class GeoElevationData:
         else:
             east_west = 'W'
 
-        file_name = '%s%s%s%s.hgt' % (north_south, str(int(abs(mod_math.floor(latitude)))).zfill(2), 
+        file_name = '%s%s%s%s.hgt' % (north_south, str(int(abs(mod_math.floor(latitude)))).zfill(2),
                                       east_west, str(int(abs(mod_math.floor(longitude)))).zfill(3))
 
         if not (file_name in self.srtm1_files) and not (file_name in self.srtm3_files):
@@ -156,7 +152,7 @@ class GeoElevationData:
 
         return file_name
 
-    def get_image(self, size, latitude_interval, longitude_interval, max_elevation, 
+    def get_image(self, size, latitude_interval, longitude_interval, max_elevation,
                   unknown_color = (255, 255, 255, 255), zero_color = (0, 0, 255, 255),
                   min_color = (0, 0, 0, 255), max_color = (0, 255, 0, 255),
                   mode='image'):
@@ -165,7 +161,7 @@ class GeoElevationData:
         """
         import Image as mod_image
         import ImageDraw as mod_imagedraw
-        import numpy as np 
+        import numpy as np
 
         if not size or len(size) != 2:
             raise Exception('Invalid size %s' % size)
@@ -246,7 +242,7 @@ class GeoElevationData:
 
     def _add_interval_elevations(self, gpx, min_interval_length=100):
         """
-        Adds elevation on points every min_interval_length and add missing 
+        Adds elevation on points every min_interval_length and add missing
         elevation between
         """
         for track in gpx.tracks:
@@ -288,13 +284,13 @@ class GeoElevationFile:
     """
     Contains data from a single Shuttle elevation file.
 
-    This class hould not be instantiated without its GeoElevationData because 
+    This class hould not be instantiated without its GeoElevationData because
     it may need elevations from nearby files.
     """
 
     file_name = None
     url = None
-	
+
     latitude = None
     longitude = None
 
@@ -321,7 +317,7 @@ class GeoElevationFile:
 
     def get_elevation(self, latitude, longitude, approximate=None):
         """
-        If approximate is True then only the points from SRTM grid will be 
+        If approximate is True then only the points from SRTM grid will be
         used, otherwise a basic aproximation of nearby points will be calculated.
         """
         if not (self.latitude <= latitude < self.latitude + 1):
@@ -337,17 +333,17 @@ class GeoElevationFile:
             return self.approximation(latitude, longitude)
         else:
             return self.get_elevation_from_row_and_column(int(row), int(column))
-    
+
     def approximation(self, latitude, longitude):
         """
-        Dummy approximation with nearest points. The nearest the neighbour the 
+        Dummy approximation with nearest points. The nearest the neighbour the
         more important will be its elevation.
         """
         d = 1. / self.square_side
         d_meters = d * mod_utils.ONE_DEGREE
 
-        # Since the less the distance => the more important should be the 
-        # distance of the point, we'll use d-distance as importance coef 
+        # Since the less the distance => the more important should be the
+        # distance of the point, we'll use d-distance as importance coef
         # here:
         importance_1 = d_meters - mod_utils.distance(latitude + d, longitude, latitude, longitude)
         elevation_1  = self.geo_elevation_data.get_elevation(latitude + d, longitude, approximate=False)
@@ -360,7 +356,7 @@ class GeoElevationFile:
 
         importance_4 = d_meters - mod_utils.distance(latitude, longitude - d, latitude, longitude)
         elevation_4  = self.geo_elevation_data.get_elevation(latitude, longitude - d, approximate=False)
-        # TODO(TK) Check if coordinates inside the same file, and only the decide if to xall 
+        # TODO(TK) Check if coordinates inside the same file, and only the decide if to xall
         # self.geo_elevation_data.get_elevation or just self.get_elevation
 
         if elevation_1 == None or elevation_2 == None or elevation_3 == None or elevation_4 == None:
@@ -424,6 +420,6 @@ class GeoElevationFile:
 
         self.latitude = latitude
         self.longitude = longitude
-	
+
     def __str__(self):
         return '[{0}:{1}]'.format(self.__class__, self.file_name)

--- a/srtm/main.py
+++ b/srtm/main.py
@@ -35,28 +35,28 @@ def get_data(srtm1=True, srtm3=True, leave_zipped=False, file_handler=None,
     """
     Get the utility object for querying elevation data.
 
-    All data files will be stored in localy (note that it may be 
+    All data files will be stored in localy (note that it may be
     gigabytes of data so clean it from time to time).
 
-    On first run -- all files needed url will be stored and for every next 
-    elevation query if the SRTM file is not found it will be retrieved and 
+    On first run -- all files needed url will be stored and for every next
+    elevation query if the SRTM file is not found it will be retrieved and
     saved.
 
-    If you need to change the way the files are saved locally (for example if 
-    you need to save them locally) -- change the file_handler. See 
+    If you need to change the way the files are saved locally (for example if
+    you need to save them locally) -- change the file_handler. See
     srtm.main.FileHandler.
 
-    If leave_zipped is True then files will be stored locally as compressed 
-    zip files. That means less disk space but more computing space for every 
+    If leave_zipped is True then files will be stored locally as compressed
+    zip files. That means less disk space but more computing space for every
     file loaded.
 
-    If use_included_urls is True urls to SRTM files included in the library 
+    If use_included_urls is True urls to SRTM files included in the library
     will be used. Set to false if you need to reload them on first run.
 
-    With srtm1 or srtm3 params you can decide which SRTM format to use. Srtm3 
-    has a resolution of three arc-seconds (cca 90 meters between points). 
-    Srtm1 has a resolution of one arc-second (cca 30 meters). Srtm1 is 
-    available only for the United states. If both srtm1 ans srtm3 are True and 
+    With srtm1 or srtm3 params you can decide which SRTM format to use. Srtm3
+    has a resolution of three arc-seconds (cca 90 meters between points).
+    Srtm1 has a resolution of one arc-second (cca 30 meters). Srtm1 is
+    available only for the United states. If both srtm1 ans srtm3 are True and
     both files are present for a location -- the srtm1 will be used.
     """
     if not file_handler:
@@ -104,7 +104,7 @@ def _get_urls_json(use_included_urls, file_handler):
 
 class FileHandler:
     """
-    The default file handler. It can be changed if you need to save/read SRTM 
+    The default file handler. It can be changed if you need to save/read SRTM
     files in a database or Amazon S3.
     """
 

--- a/srtm/utils.py
+++ b/srtm/utils.py
@@ -19,10 +19,11 @@ import pdb
 import logging    as mod_logging
 import math       as mod_math
 import zipfile    as mod_zipfile
+
 try:
-    import cStringIO as mod_cstringio
-except:
-    from io import StringIO as mod_cstringio
+    from StringIO import cStringIO
+except ImportError: # assume this is Python 3
+    from io import BytesIO as cStringIO # looks hacky but we are working with bytes
 
 ONE_DEGREE = 1000. * 10000.8 / 90.
 
@@ -49,7 +50,7 @@ def get_color_between(color1, color2, i):
 
 def zip(contents, file_name):
     mod_logging.debug('Zipping %s bytes' % len(contents))
-    result = mod_cstringio.StringIO()
+    result = cStringIO()
     zip_file = mod_zipfile.ZipFile(result, 'w', mod_zipfile.ZIP_DEFLATED, False)
     zip_file.writestr(file_name, contents)
     zip_file.close()
@@ -59,7 +60,7 @@ def zip(contents, file_name):
 
 def unzip(contents):
     mod_logging.debug('Unzipping %s bytes' % len(contents))
-    zip_file = mod_zipfile.ZipFile(mod_cstringio.StringIO(contents))
+    zip_file = mod_zipfile.ZipFile(cStringIO(contents))
     zip_info_list = zip_file.infolist()
     zip_info = zip_info_list[0]
     result = zip_file.open(zip_info).read()


### PR DESCRIPTION
It seems that the current master branch is not Python 3.x compatible. These changes resolve this. The actual change is pretty small, the remaining diff is just removal of trailing white spaces. Could you please merge and make a release? 
It is also a good habit to tag the version you uploaded to PyPI on github so that users can easily find out to which commit a version on PyPI actually refers to. I also noticed that you are using the ``requests`` package but you did not declare it as dependency in ``setup.py``. 
Thanks for your great work in providing a useful tool like that!