### PR TITLE
Added requests as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ mod_distutilscore.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
     ],
+    requires=['requests'],
     scripts=['gpxelevations']
 )
 


### PR DESCRIPTION
The external library requests is used by srtm.py but not defined in setup.py. This had the disadvantage that pip can't resolved the dependencies and people installing srtm.py need to figure that out themselves after having installed it. 