### PR TITLE
Add timeout check on requests.get call

### DIFF
--- a/srtm/data.py
+++ b/srtm/data.py
@@ -106,7 +106,10 @@ class GeoElevationData:
             #mod_logging.error('No file found: {0}'.format(file_name))
             return None
 
-        r = mod_requests.get(url)
+        try:
+            r = mod_requests.get(url, timeout=5)
+        except mod_requests.exceptions.Timeout:
+            raise Exception('Connection to %s failed (timeout)' % url)
         if r.status_code < 200 or 300 <= r.status_code:
             raise Exception('Cannot retrieve %s' % url)
         mod_logging.info('Retrieving {0}'.format(url))


### PR DESCRIPTION
Add a 5-second timeout check over the connection to the SRTM data servers in case they would not respond. Else a `get_elevation` call could hang.