### PR TITLE
Remove build for Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: false
 # Those without lxml wheels first because building lxml is slow
 python:
  - 3.5
- - 3.2
  - 2.7
  - 2.6
  - 3.4


### PR DESCRIPTION
As per the Python Requests library, which is a listed dependency of
SRTM.py, `Requests officially supports Python 2.6–2.7 & 3.3–3.5, and
runs great on PyPy`.