### PR TITLE
Add a min_elevation parameter, to make it possible to see data in hig…

### DIFF
--- a/srtm/data.py
+++ b/srtm/data.py
@@ -151,7 +151,7 @@ class GeoElevationData:
 
         return file_name
 
-    def get_image(self, size, latitude_interval, longitude_interval, max_elevation,
+    def get_image(self, size, latitude_interval, longitude_interval, max_elevation, min_elevation=0,
                   unknown_color = (255, 255, 255, 255), zero_color = (0, 0, 255, 255),
                   min_color = (0, 0, 0, 255), max_color = (0, 255, 0, 255),
                   mode='image'):
@@ -195,6 +195,8 @@ class GeoElevationData:
                               (255, 255, 255, 255))
             draw = mod_imagedraw.Draw(image)
 
+            max_elevation -= min_elevation
+
             for row in range(height):
                 for column in range(width):
                     latitude  = latitude_from  + float(row) / height * (latitude_to  - latitude_from)
@@ -203,7 +205,7 @@ class GeoElevationData:
                     if elevation == None:
                         color = unknown_color
                     else:
-                        elevation_coef = elevation / float(max_elevation)
+                        elevation_coef = (elevation - min_elevation) / float(max_elevation)
                         if elevation_coef < 0: elevation_coef = 0
                         if elevation_coef > 1: elevation_coef = 1
                         color = mod_utils.get_color_between(min_color, max_color, elevation_coef)


### PR DESCRIPTION
get_image() is brilliant (as is the whole module -- thanks!) But in high elevation areas, it's almost impossible to see any contrast in the resulting image. It helps a lot to be able to pass a minimum elevation as well as a maximum.

Example of a place where it makes a difference:
```
    geo_elevation_data = srtm.get_data()
    image = geo_elevation_data.get_image((500, 500),
                      (35.8, 35.9), (-106.3, -106.2),
                     2260, min_elevation=1750,
                      max_color = (255, 255, 255, 255),
                      unknown_color = (255, 0, 0, 255))
    image.show()
