### PR TITLE
Add batch_mode option to get_file to mitigate memory issues caused by local caching of files

### DIFF
--- a/srtm/data.py
+++ b/srtm/data.py
@@ -41,7 +41,7 @@ class GeoElevationData:
     files = None
 
     def __init__(self, srtm1_files, srtm3_files, leave_zipped=False,
-                 file_handler=None):
+                 file_handler=None, batch_mode=False):
         self.srtm1_files = srtm1_files
         self.srtm3_files = srtm3_files
 
@@ -50,6 +50,8 @@ class GeoElevationData:
         self.file_handler = file_handler if file_handler else mod_utils.FileHandler()
 
         self.files = {}
+
+        self.batch_mode = batch_mode
 
     def get_elevation(self, latitude, longitude, approximate=None):
         geo_elevation_file = self.get_file(float(latitude), float(longitude))
@@ -82,7 +84,13 @@ class GeoElevationData:
                 return None
 
             result = GeoElevationFile(file_name, data, self)
-            self.files[file_name] = result
+
+            # Store file (if in batch mode, just keep most recent)
+            if self.batch_mode:
+                self.files = {file_name: result}
+            else:
+                self.files[file_name] = result
+
             return result
 
     def retrieve_or_load_file_data(self, file_name):

--- a/srtm/main.py
+++ b/srtm/main.py
@@ -28,7 +28,7 @@ package_location = mod_data.__file__[: mod_data.__file__.rfind(mod_path.sep)]
 DEFAULT_LIST_JSON = package_location + mod_os.sep + 'list.json'
 
 def get_data(srtm1=True, srtm3=True, leave_zipped=False, file_handler=None,
-             use_included_urls=True):
+             use_included_urls=True, batch_mode=False):
     """
     Get the utility object for querying elevation data.
 
@@ -49,6 +49,12 @@ def get_data(srtm1=True, srtm3=True, leave_zipped=False, file_handler=None,
 
     If use_included_urls is True urls to SRTM files included in the library
     will be used. Set to false if you need to reload them on first run.
+
+    If batch_mode is True, only the most recent file will be stored. This is
+    ideal for situations where you want to use this function to enrich a very
+    large dataset. If your data are spread over a wide geographic area, this
+    setting will make this function slower but will greatly reduce the risk
+    of out-of-memory errors. Default is False.
 
     With srtm1 or srtm3 params you can decide which SRTM format to use. Srtm3
     has a resolution of three arc-seconds (cca 90 meters between points).
@@ -75,7 +81,7 @@ def get_data(srtm1=True, srtm3=True, leave_zipped=False, file_handler=None,
     assert srtm1_files or srtm3_files
 
     return mod_data.GeoElevationData(srtm1_files, srtm3_files, file_handler=file_handler,
-                                     leave_zipped=leave_zipped)
+                                     leave_zipped=leave_zipped, batch_mode=batch_mode)
 
 def _get_urls(use_included_urls, file_handler):
     files_list_file_name = 'list.json'

--- a/test.py
+++ b/test.py
@@ -144,3 +144,26 @@ class Tests(mod_unittest.TestCase):
 
         self.assertNotEquals(elevation_with_approximation, elevation_without_approximation)
         self.assertTrue(abs(elevation_with_approximation - elevation_without_approximation) < 30)
+
+    def test_batch_mode(self):
+        
+        # Two pulls that are far enough apart to require multiple files
+
+        # With batch_mode=False, both files should be kept
+        geo_elevation_data = mod_srtm.get_data(batch_mode=False)
+
+        elevation1 = geo_elevation_data.get_elevation(42.3467, 71.0972)
+        self.assertTrue(len(geo_elevation_data.files) == 1)
+
+        elevation2 = geo_elevation_data.get_elevation(43.0382, 87.9298)
+        self.assertTrue(len(geo_elevation_data.files) == 2)
+
+        # With batch_mode=True, only the most recent file should be kept
+        geo_elevation_data = mod_srtm.get_data(batch_mode=True)
+        elevation1 = geo_elevation_data.get_elevation(42.3467, 71.0972)
+        self.assertTrue(len(geo_elevation_data.files) == 1)
+        keys1 = geo_elevation_data.files.keys()
+
+        elevation2 = geo_elevation_data.get_elevation(43.0382, 87.9298)
+        self.assertTrue(len(geo_elevation_data.files) == 1)
+        self.assertFalse(geo_elevation_data.files.keys() == keys1)


### PR DESCRIPTION
I love this module and find it incredibly useful. I also understand that local caching of the pulled files makes it very fast when you are making many queries for data in the same geographic area.

When using this module to label a large, global dataset (making millions of requests), I found that I was running into memory issues because of the diversity of files needed to satisfy my requests. In this PR, I propose a small change to address this. With this change, users who are running large ETL jobs can reliably use this module without worrying about running out of memory.